### PR TITLE
Allow setting config in package.json

### DIFF
--- a/bin/customizr
+++ b/bin/customizr
@@ -58,7 +58,7 @@ if (opts.help) {
 		if (fs.existsSync(opts.config)) {
 			config = JSON.parse(fs.readFileSync(opts.config));
 
-			if (path.parse(opts.config).base === 'package.json') {
+			if (path.basename(opts.config) === 'package.json') {
 			    config = configInPackage();
 			}
 		} else {

--- a/bin/customizr
+++ b/bin/customizr
@@ -34,6 +34,20 @@ function help() {
 	return out.join("\n");
 }
 
+function normalizeSlashes(string) {
+    return string.replace(/\\/g, '/');
+}
+
+function configInPackage()
+{
+    var config = JSON.parse(fs.readFileSync('package.json'));
+    if ('customizr' in config) {
+        return config.customizr;
+    }
+
+    return {};
+}
+
 if (opts.help) {
 	process.stdout.write(help());
 	return process.exit();
@@ -42,14 +56,22 @@ if (opts.help) {
 	return process.exit();
 } else {
 	var config = {};
+	configInPackage();
 
 	if (opts.config) {
+
 		if (fs.existsSync(opts.config)) {
 			config = JSON.parse(fs.readFileSync(opts.config));
+
+			if (path.parse(opts.config).base === 'package.json') {
+			    config = configInPackage();
+			}
 		} else {
 			process.stderr.write("Path does not exist.");
 			return process.exit();
 		}
+	} else {
+	    config = configInPackage();
 	}
 
 	return customizr(config, process.exit);

--- a/bin/customizr
+++ b/bin/customizr
@@ -34,10 +34,6 @@ function help() {
 	return out.join("\n");
 }
 
-function normalizeSlashes(string) {
-    return string.replace(/\\/g, '/');
-}
-
 function configInPackage()
 {
     var config = JSON.parse(fs.readFileSync('package.json'));
@@ -56,7 +52,6 @@ if (opts.help) {
 	return process.exit();
 } else {
 	var config = {};
-	configInPackage();
 
 	if (opts.config) {
 


### PR DESCRIPTION
Changes allow for setting the config file to package.json and also to default to package.json if the config isn't set. If the "customizr" key isn't found, then it's set to an empty object.

What do you think?